### PR TITLE
fix: 修复重新安装插件时 deletePlugin 解构崩溃

### DIFF
--- a/src/main/store.js
+++ b/src/main/store.js
@@ -21,7 +21,7 @@ function showErrorDialog(title, message) {
 function getDestPath(manifest_text) {
     const { slug } = JSON.parse(manifest_text);
     let dest_path = path.join(LiteLoader.path.plugins, slug);
-    if (slug in LiteLoader.plugins) LiteLoader.api.plugin.delete(slug, false, false);
+    if (slug in LiteLoader.plugins) LiteLoader.api.plugin.delete(slug, [false, false], false);
     if (fs.existsSync(dest_path)) dest_path += `_${Date.now()}`;
     return dest_path;
 }


### PR DESCRIPTION
## 问题

通过 LiteLoader 设置页面的 zip 上传功能重新安装已有插件时，会报错：

```
TypeError: boolean false is not iterable (cannot read property Symbol(Symbol.iterator))
```

### 原因

`store.js` 中 `getDestPath` 函数（第 24 行）调用：

```js
LiteLoader.api.plugin.delete(slug, false, false);
```

但 `deletePlugin` 的函数签名为：

```js
exports.deletePlugin = (slug, [self, data], now) => { ... }
```

第二个参数需要数组类型以进行解构，但实际传入了 `boolean false`，导致解构失败。

### 修复

```diff
- if (slug in LiteLoader.plugins) LiteLoader.api.plugin.delete(slug, false, false);
+ if (slug in LiteLoader.plugins) LiteLoader.api.plugin.delete(slug, [false, false], false);
```

### 影响

- 全新安装不受影响（`slug in LiteLoader.plugins` 为 false，不会进入该分支）
- 仅在重新安装/更新已安装的插件时触发崩溃

### 测试环境

| 组件 | 版本 |
|------|------|
| LiteLoader | 1.4.1 |
| QQNT | 6.9.86-42941 |
| 系统 | Arch Linux |